### PR TITLE
Fix nng endpoints

### DIFF
--- a/configs/local.yaml
+++ b/configs/local.yaml
@@ -1,4 +1,4 @@
-transport: "nng"
+transport: "udp"
 
 client:
   ips: 

--- a/configs/local.yaml
+++ b/configs/local.yaml
@@ -1,8 +1,9 @@
-transport: "udp"
+transport: "nng"
 
 client:
   ips: 
-  - "127.0.0.10"
+  - "127.0.1.0"
+  - "127.0.1.1"
   port: 33000
   keysDir: keys/client
   maxRequests: 1
@@ -12,6 +13,7 @@ client:
 proxy:
   ips: 
     - "127.0.0.9"  
+    - "127.0.0.10"  
   shards: 1
   forwardPort: 31000
   measurementPort: 32000

--- a/processes/client/client.cc
+++ b/processes/client/client.cc
@@ -19,21 +19,7 @@ namespace dombft
         int clientPort = config.clientPort;
         LOG(INFO) << "clientPort=" << clientPort;
 
-        /** Store all proxy addrs. TODO handle mutliple proxy sockets*/
-        for (uint32_t i = 0; i < config.proxyIps.size(); i++)
-        {
-            LOG(INFO) << "Proxy " << i + 1 << ": " << config.proxyIps[i] << ", " << config.proxyForwardPort;
-            proxyAddrs_.push_back(Address(config.proxyIps[i],
-                                          config.proxyForwardPort));
-        }
-
-        /** Store all replica addrs */
-        for (uint32_t i = 0; i < config.replicaIps.size(); i++)
-        {
-            replicaAddrs_.push_back(Address(config.replicaIps[i],
-                                            config.replicaPort));
-        }
-        f_ = replicaAddrs_.size() / 3;
+        f_ = config.replicaIps.size() / 3;
 
         /* Setup keys */
         std::string clientKey = config.clientKeysDir + "/client" + std::to_string(clientId_) + ".pem";
@@ -54,21 +40,44 @@ namespace dombft
         LOG(INFO) << "Simulating " << config.clientMaxRequests << " simultaneous clients!";
         maxInFlight_ = config.clientMaxRequests;
 
-
-        /** Initialize state */
-        nextReqSeq_ = 1;
-
+        /** Setup transport */
         if (config.transport == "nng") {
             auto addrPairs = getClientAddrs(config, clientId_);
 
-            // TODO get replica addresses correctly
-
             endpoint_ = std::make_unique<NngEndpoint>(addrPairs, true);
+
+            for (size_t i = 0; i < addrPairs.size(); i++) 
+            {
+            }
+
+            size_t nReplicas = config.replicaIps.size();
+            for (size_t i = 0; i < nReplicas; i++) 
+                replicaAddrs_.push_back(addrPairs[i].second);
+
+            for (size_t i = nReplicas; i < addrPairs.size(); i++)
+                proxyAddrs_.push_back(addrPairs[i].second);
         }
         else {
             endpoint_ = std::make_unique<UDPEndpoint>(clientIp, clientPort, true);
+
+            /** Store all proxy addrs. TODO handle mutliple proxy sockets*/
+            for (uint32_t i = 0; i < config.proxyIps.size(); i++)
+            {
+                LOG(INFO) << "Proxy " << i + 1 << ": " << config.proxyIps[i] << ", " << config.proxyForwardPort;
+                proxyAddrs_.push_back(Address(config.proxyIps[i],
+                                              config.proxyForwardPort));
+            }
+
+            /** Store all replica addrs */
+            for (uint32_t i = 0; i < config.replicaIps.size(); i++)
+            {
+                replicaAddrs_.push_back(Address(config.replicaIps[i],
+                                                config.replicaPort));
+            }
         }
-        
+    
+        /** Initialize state */
+        nextReqSeq_ = 1;
         
         MessageHandlerFunc replyHandler = [this](MessageHeader *msgHdr, byte *msgBuffer, Address *sender)
         {
@@ -86,6 +95,9 @@ namespace dombft
             this);
 
         endpoint_->RegisterTimer(timeoutTimer_.get());
+
+
+        LOG(INFO) << "Client finished initializing";
     }
 
     Client::~Client()

--- a/processes/client/client.cc
+++ b/processes/client/client.cc
@@ -123,9 +123,10 @@ namespace dombft
             return;
         }
 
-        Reply reply;
         if (msgHdr->msgType == MessageType::REPLY || msgHdr->msgType == MessageType::FAST_REPLY)
         {
+            Reply reply;
+
             // TODO verify and handle signed header better
             if (!reply.ParseFromArray(msgBuffer, msgHdr->msgLen))
             {
@@ -209,8 +210,8 @@ namespace dombft
                 return;
             }
 
-            if (reply.client_id() != clientId_) {
-                VLOG(2) << "Received certReply for client " << reply.client_id()  << " != " << clientId_;
+            if (certReply.client_id() != clientId_) {
+                VLOG(2) << "Received certReply for client " << certReply.client_id()  << " != " << clientId_;
                 return;
  
             }

--- a/processes/config_util.cc
+++ b/processes/config_util.cc
@@ -106,7 +106,6 @@ vector<pair<Address, Address>> getReplicaAddrs(ProcessConfig config, uint32_t id
     uint32_t replicaPort = config.replicaPort + config.clientIps.size();
     uint32_t receiverPort = config.receiverPort + 2 * config.proxyIps.size();
 
-
     if (config.receiverLocal) {
         // 5b. above
         // TODO use IPC instead of localhost?
@@ -116,8 +115,12 @@ vector<pair<Address, Address>> getReplicaAddrs(ProcessConfig config, uint32_t id
         addAddrPairs(ret, replicaIp, replicaPort, {config.receiverIps[id]}, receiverPort);    
     }
 
-
     // TODO add replica ports
+    replicaBase = config.replicaPort + config.clientIps.size() + 1;
+    uint32_t myPort = replicaBase + id;
+
+    addAddrPairs(ret, replicaIp, myPort, config.replicaIps, replicaBase);    
+
 
     return ret;
 }

--- a/processes/config_util.h
+++ b/processes/config_util.h
@@ -22,7 +22,7 @@
  *              receiverBase + numProxies * 2 <==> replicaBase + numClients
  *      5b. Each replica/receiver own machine
  *              (127.0.0.1) receiverBase + numProxies * 2 <==> (127.0.0.2) replicaBase + numClients
- * 
+ *      6. Replica/replica communication
  */
 
 

--- a/processes/proxy/proxy.cc
+++ b/processes/proxy/proxy.cc
@@ -33,8 +33,7 @@ namespace dombft
                 exit(1);
             }
             auto addrPairs = getProxyAddrs(config, proxyId);
-            // This is rather messy, but the 'nClients'th addresss pair is for forwarding,
-            // last nReceivers addresses in this return value are for the measurement connections 
+            // This is rather messy, but the last nReceivers addresses in this return value are for the measurement connections 
             size_t nClients = config.clientIps.size();
             size_t nReplicas = config.replicaIps.size();
             std::vector<std::pair<Address, Address>> forwardAddrs(addrPairs.begin(), addrPairs.end() - config.receiverIps.size());
@@ -45,7 +44,6 @@ namespace dombft
 
             for (int i = nClients; i < forwardAddrs.size(); i++)
             {
-                LOG(INFO) << forwardAddrs[i].second.ip_;
                 receiverAddrs_.push_back(forwardAddrs[i].second);
             }
 

--- a/processes/proxy/proxy.cc
+++ b/processes/proxy/proxy.cc
@@ -33,13 +33,22 @@ namespace dombft
                 exit(1);
             }
             auto addrPairs = getProxyAddrs(config, proxyId);
-            // This is rather messy, but the last nReceivers addresses in this return value are 
-            // for the measurement connections  o
+            // This is rather messy, but the 'nClients'th addresss pair is for forwarding,
+            // last nReceivers addresses in this return value are for the measurement connections 
+            size_t nClients = config.clientIps.size();
+            size_t nReplicas = config.replicaIps.size();
             std::vector<std::pair<Address, Address>> forwardAddrs(addrPairs.begin(), addrPairs.end() - config.receiverIps.size());
             std::vector<std::pair<Address, Address>> measurmentAddrs(addrPairs.end() - config.receiverIps.size(), addrPairs.end());
 
             forwardEps_.push_back(std::make_unique<NngEndpoint>(forwardAddrs, false));
             measurmentEp_ = std::make_unique<NngEndpoint>(measurmentAddrs);
+
+            for (int i = nClients; i < forwardAddrs.size(); i++)
+            {
+                LOG(INFO) << forwardAddrs[i].second.ip_;
+                receiverAddrs_.push_back(forwardAddrs[i].second);
+            }
+
 
         } else {
             for (int i = 0; i < numShards_; i++)
@@ -51,14 +60,17 @@ namespace dombft
 
             measurmentEp_ = std::make_unique<UDPEndpoint>(
                 config.proxyIps[proxyId], config.proxyMeasurementPort);
+
+
+            numReceivers_ = config.receiverIps.size();
+            for (int i = 0; i < numReceivers_; i++)
+            {
+                std::string receiverIp = config.receiverIps[i];
+                receiverAddrs_.push_back(Address(receiverIp, config.receiverPort));
+            }
         }
 
-        numReceivers_ = config.receiverIps.size();
-        for (int i = 0; i < numReceivers_; i++)
-        {
-            std::string receiverIp = config.receiverIps[i];
-            receiverAddrs_.push_back(Address(receiverIp, config.receiverPort));
-        }
+
     }
 
     void Proxy::terminate()

--- a/processes/replica/replica.cc
+++ b/processes/replica/replica.cc
@@ -436,8 +436,9 @@ namespace dombft
         reply.set_client_id(r.client_id());
         reply.set_client_seq(r.client_seq());
         reply.set_replica_id(replicaId_);
-
-        VLOG(3) << "Sending cert for " << reply.client_id() << ", " << reply.client_seq();
+ 
+        VLOG(3) << "Sending cert ack for " << reply.client_id() << ", " << reply.client_seq()
+        << " to " << clientAddrs_[reply.client_id()].GetIPAsString();
 
         // TODO set result
         MessageHeader *hdr = endpoint_->PrepareProtoMsg(reply, MessageType::CERT_REPLY);

--- a/processes/replica/replica.cc
+++ b/processes/replica/replica.cc
@@ -50,35 +50,49 @@ namespace dombft
             exit(1);
         }
 
-        /** Store all replica addrs */
-        for (uint32_t i = 0; i < config.replicaIps.size(); i++)
-        {
-            replicaAddrs_.push_back(Address(config.replicaIps[i],
-                                            config.replicaPort));
-        }
-        f_ = replicaAddrs_.size() / 3;
 
-        /** Store all client addrs */
-        for (uint32_t i = 0; i < config.clientIps.size(); i++)
-        {
-            clientAddrs_.push_back(Address(config.clientIps[i],
-                                           config.clientPort));
-        }
+        f_ = config.replicaIps.size() / 3;
+
+
 
         log_ = std::make_unique<Log>();
 
         if (config.transport == "nng")
         {
             auto addrPairs = getReplicaAddrs(config, replicaId_);
-
-            // TODO get replica addresses correctly
-
             endpoint_ = std::make_unique<NngEndpoint>(addrPairs, true);
+
+            size_t nClients = config.clientIps.size();
+            for (size_t i = 0; i < nClients; i++) {
+                // LOG(INFO) << "Client " << i << ": " << addrPairs[i].second.GetIPAsString();
+                clientAddrs_.push_back(addrPairs[i].second);
+            }
+
+            for (size_t i = nClients + 1; i < addrPairs.size(); i++) {
+                // LOG(INFO) << "Replica " << i << ": " <<  addrPairs[i].second.GetIPAsString();
+                replicaAddrs_.push_back(addrPairs[i].second);
+            }
         }
         else
         {
             endpoint_ = std::make_unique<UDPEndpoint>(bindAddress, replicaPort, true);
+
+            /** Store all replica addrs */
+            for (uint32_t i = 0; i < config.replicaIps.size(); i++)
+            {
+                replicaAddrs_.push_back(Address(config.replicaIps[i],
+                                                config.replicaPort));
+            }
+
+            /** Store all client addrs */
+            for (uint32_t i = 0; i < config.clientIps.size(); i++)
+            {
+                clientAddrs_.push_back(Address(config.clientIps[i],
+                                               config.clientPort));
+            }
         }
+
+
         MessageHandlerFunc handler = [this](MessageHeader *msgHdr, byte *msgBuffer, Address *sender)
         {
             this->handleMessage(msgHdr, msgBuffer, sender);


### PR DESCRIPTION
I had implemented NNG endpoints wrong, since the processes would need to rewrite their arrays of destination addresses, which were originally only the base port. I fixed it here with some ugly code lol.

It worked originally completely by coincidence, because there was only 1 client and proxy.