### PR TITLE
Add a loopback path instead of localhost

### DIFF
--- a/processes/config_util.cc
+++ b/processes/config_util.cc
@@ -119,18 +119,8 @@ vector<pair<Address, Address>> getReplicaAddrs(ProcessConfig config, uint32_t id
     replicaBase = config.replicaPort + config.clientIps.size() + 1;
 
     // Each replica just uses (base + i) to connect with replica i
-    // For itself, we create a nng pairs on both sides, betwen (base + n) and (base + id)
-    // And in replica we need to account for this.
-    // This is not ideal at all though...
     for (uint32_t i = 0; i < config.replicaIps.size(); i++) {
-        if (i == id) {
-            ret.push_back({Address(replicaIp, replicaBase + id),
-                           Address(config.replicaIps[i], replicaBase + config.replicaIps.size())});
-            ret.push_back({Address(replicaIp, replicaBase + config.replicaIps.size()),
-                           Address(config.replicaIps[i], replicaBase + id)});
-        } else {
-            ret.push_back({Address(replicaIp, replicaBase + i), Address(config.replicaIps[i], replicaBase + id)});
-        }
+        ret.push_back({Address(replicaIp, replicaBase + i), Address(config.replicaIps[i], replicaBase + id)});
     }
 
     return ret;

--- a/processes/replica/replica.h
+++ b/processes/replica/replica.h
@@ -18,6 +18,9 @@
 #include <yaml-cpp/yaml.h>
 
 namespace dombft {
+using msgSigPair = std::pair<const google::protobuf::Message&, const std::span<byte>&>;
+using msgHandlingFunc = std::function<void(const msgSigPair&)>;
+
 class Replica {
 private:
     uint32_t replicaId_;
@@ -50,6 +53,8 @@ private:
     std::map<int, dombft::proto::Commit> checkpointCommits_;
     std::map<int, std::string> checkpointCommitSigs_;
 
+
+
     // State for fallback
     bool fallback_ = false;
     uint32_t fallbackTriggerSeq_ = 0;
@@ -67,12 +72,38 @@ private:
     uint32_t swapFreq_;
     std::optional<proto::ClientRequest> heldRequest_;
 
+    // dispatching loopback messages
+    const std::unordered_map<MessageType,msgHandlingFunc> loopbackDispatch_ = {
+            {MessageType::REPLY, [this](const msgSigPair& msgSig){
+                handleReply(dynamic_cast<const dombft::proto::Reply&>(msgSig.first), msgSig.second);
+            }},
+            {MessageType::COMMIT, [this](const msgSigPair& msgSig) {
+                handleCommit(dynamic_cast<const dombft::proto::Commit&>(msgSig.first), msgSig.second);
+            }},
+            {MessageType::FALLBACK_TRIGGER, [this](const msgSigPair& msgSig) {
+                return;
+            }},
+            {MessageType::FALLBACK_START, [this](const msgSigPair& msgSig) {
+                handleFallbackStart(dynamic_cast<const dombft::proto::FallbackStart&>(msgSig.first), msgSig.second);
+            }},
+            {MessageType::DUMMY_PREPREPARE, [this](const msgSigPair& msgSig) {
+                handlePrePrepare(dynamic_cast<const dombft::proto::FallbackPrePrepare&>(msgSig.first));
+            }},
+            {MessageType::DUMMY_PREPARE, [this](const msgSigPair& msgSig) {
+                handlePrepare(dynamic_cast<const dombft::proto::FallbackPrepare&>(msgSig.first));
+            }},
+            {MessageType::DUMMY_COMMIT, [this](const msgSigPair& msgSig) {
+                handlePBFTCommit(dynamic_cast<const dombft::proto::FallbackPBFTCommit&>(msgSig.first));
+            }},
+    };
+
     void handleMessage(MessageHeader *msgHdr, byte *msgBuffer, Address *sender);
     void handleClientRequest(const dombft::proto::ClientRequest &request);
     void handleCert(const dombft::proto::Cert &cert);
     void handleReply(const dombft::proto::Reply &reply, std::span<byte> sig);
     void handleCommit(const dombft::proto::Commit &commitMsg, std::span<byte> sig);
 
+    void sendMsgToDst(const google::protobuf::Message &msg, MessageType type, const Address &dst);
     void broadcastToReplicas(const google::protobuf::Message &msg, MessageType type);
     bool verifyCert(const dombft::proto::Cert &cert);
 

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -155,7 +155,7 @@ def get_gcloud_process_group(config, ext_ips):
 
 
 @task
-def gcloud_clockwork(c, config_file="../configs/remote.yaml", install=False):
+def gcloud_clockwork(c, config_file="../configs/remote-prod.yaml", install=False):
     config_file = os.path.abspath(config_file)
 
     with open(config_file) as cfg_file:
@@ -198,7 +198,7 @@ def gcloud_clockwork(c, config_file="../configs/remote.yaml", install=False):
 
 
 @task
-def gcloud_build(c, config_file="../configs/remote.yaml", setup=False):
+def gcloud_build(c, config_file="../configs/remote-prod.yaml", setup=False):
     config_file = os.path.abspath(config_file)
 
     with open(config_file) as cfg_file:
@@ -215,8 +215,9 @@ def gcloud_build(c, config_file="../configs/remote.yaml", setup=False):
     print("Cloning/building repo...")
 
     group.run("git clone https://github.com/dqian3/DOM-BFT", warn=True)
-    group.run("cd DOM-BFT && git pull && bazel build //processes/...")
+    group.run("cd DOM-BFT && git pull --rebase && bazel build //processes/...")
 
+    group.run("rm ~/dombft_*", warn=True)
     group.run("cp ./DOM-BFT/bazel-bin/processes/replica/dombft_replica ~")
     group.run("cp ./DOM-BFT/bazel-bin/processes/receiver/dombft_receiver ~")
     group.run("cp ./DOM-BFT/bazel-bin/processes/proxy/dombft_proxy ~")
@@ -224,7 +225,7 @@ def gcloud_build(c, config_file="../configs/remote.yaml", setup=False):
 
 
 @task
-def gcloud_copy_keys(c, config_file="../configs/remote.yaml"):
+def gcloud_copy_keys(c, config_file="../configs/remote-prod.yaml"):
     config_file = os.path.abspath(config_file)
 
     with open(config_file) as cfg_file:
@@ -242,7 +243,7 @@ def gcloud_copy_keys(c, config_file="../configs/remote.yaml"):
 
 
 @task
-def gcloud_copy_bin(c, config_file="../configs/remote.yaml"):
+def gcloud_copy_bin(c, config_file="../configs/remote-prod.yaml"):
     config_file = os.path.abspath(config_file)
 
     with open(config_file) as cfg_file:
@@ -289,7 +290,7 @@ def get_gcloud_process_ips(c, filter):
 
 
 @task
-def gcloud_create_prod(c, config_template="../configs/remote.yaml"):
+def gcloud_create_prod(c, config_template="../configs/remote-prod.yaml"):
     # This is probably better, but can't be across zones:
     # https://cloud.google.com/compute/docs/instances/multiple/create-in-bulk
 
@@ -383,7 +384,7 @@ def get_logs(c, ips, log_prefix):
 
 
 @task
-def gcloud_logs(c, config_file="../configs/remote.yaml"):
+def gcloud_logs(c, config_file="../configs/remote-prod.yaml"):
 
     with open(config_file) as cfg_file:
         config = yaml.load(cfg_file, Loader=yaml.Loader)
@@ -408,7 +409,7 @@ def gcloud_logs(c, config_file="../configs/remote.yaml"):
 
 # local_log_file is good for debugging, but will slow the system down at high throughputs
 @task
-def gcloud_run(c, config_file="../configs/remote.yaml",
+def gcloud_run(c, config_file="../configs/remote-prod.yaml",
                local_log=False,
                dom_logs=False,
                slow_path_freq=0,
@@ -507,7 +508,7 @@ def gcloud_run(c, config_file="../configs/remote.yaml",
 
 
 @task
-def gcloud_reorder_exp(c, config_file="../configs/remote.yaml", 
+def gcloud_reorder_exp(c, config_file="../configs/remote-prod.yaml", 
                     poisson=False, ignore_deadlines=False, duration=20, rate=100,
                     local_log=False):
     config_file = os.path.abspath(config_file)


### PR DESCRIPTION
Check for loopback before sending. Used a dispatch map to deal with generic broadcastToReplica. Fixed redundant broadcast of fallbackTrigger. 